### PR TITLE
feat: JWT 복호화 로직 구현

### DIFF
--- a/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
+++ b/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
@@ -1,0 +1,95 @@
+package sopt.makers.jwt.verifier.application;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.text.ParseException;
+import sopt.makers.jwt.verifier.code.JwtFailure;
+import sopt.makers.jwt.verifier.exception.JwtException;
+import sopt.makers.jwt.verifier.exception.JwkException;
+import sopt.makers.jwt.verifier.infrastructure.JwkProvider;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtVerifier {
+
+    private final JwkProvider jwkProvider;
+
+    @Value("${jwt.jwk.issuer}")
+    private String issuer;
+
+    public String extractSubject(String token) {
+        try {
+            SignedJWT jwt = SignedJWT.parse(token);
+            String kid = jwt.getHeader().getKeyID();
+            PublicKey key = jwkProvider.getPublicKey(kid);
+            JWTClaimsSet claims = verifyWithRetry(jwt, kid, key);
+
+            return claims.getSubject();
+        } catch (ParseException e) {
+            log.warn("JWT parsing failed: {}", e.getMessage());
+            throw new JwtException(JwtFailure.JWT_PARSE_FAILED);
+        }
+    }
+
+    private JWTClaimsSet verifyWithRetry(SignedJWT jwt, String kid, PublicKey publicKey) throws ParseException {
+        try {
+            return verify(jwt, publicKey);
+        } catch (JOSEException e) {
+            log.warn("JWT verification failed. reason={}", e.getMessage());
+            return retryVerification(jwt, kid);
+        }
+    }
+
+    /**
+     * JWT 서명 검증 실패 시 캐시된 공개키를 무효화하고,
+     * 인증 서버에서 공개키를 다시 가져와 재검증을 시도하는 로직입니다.
+     *
+     * - JWK 캐시가 만료되었거나 잘못된 키가 저장되어 있는 경우를 대비하여,
+     *   서명 검증이 실패할 경우 한 번의 재시도 기회를 제공합니다.
+     * - 키 재조회 후에도 검증이 실패하면 JwtException을 던집니다.
+     *
+     * @param jwt 서명을 검증할 JWT
+     * @param kid JWT 헤더에 포함된 키 ID
+     * @return 검증된 JWTClaimsSet
+     * @throws ParseException JWT에서 클레임을 파싱하지 못한 경우
+     * @throws JwtException 키 재조회 후에도 검증에 실패한 경우
+     */
+    private JWTClaimsSet retryVerification(SignedJWT jwt, String kid) throws ParseException {
+        jwkProvider.invalidateKey(kid);
+        try {
+            PublicKey refreshedKey = jwkProvider.getPublicKey(kid);
+            return verify(jwt, refreshedKey);
+        } catch (JwkException | JOSEException e) {
+            log.error("Re-verification failed. reason={}", e.getMessage());
+            throw new JwtException(JwtFailure.JWT_VERIFICATION_FAILED);
+        }
+    }
+
+    private JWTClaimsSet verify(SignedJWT jwt, PublicKey publicKey) throws JOSEException, ParseException {
+        JWTClaimsSet claims = jwt.getJWTClaimsSet();
+        JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+        boolean signatureValid = jwt.verify(verifier);
+        boolean issuerValid = issuer.equals(claims.getIssuer());
+        boolean notExpired = claims.getExpirationTime().after(new Date());
+
+        if (!(signatureValid && issuerValid && notExpired)) {
+            log.warn("Invalid JWT claims detected. signatureValid={}, issuerValid={}, notExpired={}",
+                    signatureValid, issuerValid, notExpired);
+            throw new JwtException(JwtFailure.JWT_INVALID_CLAIMS);
+        }
+        return claims;
+    }
+}
+

--- a/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
+++ b/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.security.PublicKey;
 import java.text.ParseException;
-import sopt.makers.jwt.verifier.code.JwtFailure;
+import sopt.makers.jwt.verifier.code.failure.JwtFailure;
 import sopt.makers.jwt.verifier.exception.JwtException;
 import sopt.makers.jwt.verifier.exception.JwkException;
 import sopt.makers.jwt.verifier.infrastructure.JwkProvider;

--- a/src/main/java/sopt/makers/jwt/verifier/code/JwtFailure.java
+++ b/src/main/java/sopt/makers/jwt/verifier/code/JwtFailure.java
@@ -1,0 +1,18 @@
+package sopt.makers.jwt.verifier.code;
+
+import static lombok.AccessLevel.*;
+
+import lombok.*;
+import org.springframework.http.*;
+import sopt.makers.jwt.verifier.code.base.*;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum JwtFailure implements FailureCode {
+  JWT_PARSE_FAILED(HttpStatus.BAD_REQUEST, "잘못된 형식의 JWT입니다."),
+  JWT_INVALID_CLAIMS(HttpStatus.UNAUTHORIZED, "JWT의 클레임이 유효하지 않습니다."),
+  JWT_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "JWT 검증에 실패했습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/sopt/makers/jwt/verifier/code/failure/JwkFailure.java
+++ b/src/main/java/sopt/makers/jwt/verifier/code/failure/JwkFailure.java
@@ -1,4 +1,4 @@
-package sopt.makers.jwt.verifier.code.jwk;
+package sopt.makers.jwt.verifier.code.failure;
 
 import static lombok.AccessLevel.PRIVATE;
 

--- a/src/main/java/sopt/makers/jwt/verifier/code/failure/JwtFailure.java
+++ b/src/main/java/sopt/makers/jwt/verifier/code/failure/JwtFailure.java
@@ -1,4 +1,4 @@
-package sopt.makers.jwt.verifier.code;
+package sopt.makers.jwt.verifier.code.failure;
 
 import static lombok.AccessLevel.*;
 

--- a/src/main/java/sopt/makers/jwt/verifier/exception/JwkException.java
+++ b/src/main/java/sopt/makers/jwt/verifier/exception/JwkException.java
@@ -1,6 +1,6 @@
 package sopt.makers.jwt.verifier.exception;
 
-import sopt.makers.jwt.verifier.code.jwk.JwkFailure;
+import sopt.makers.jwt.verifier.code.failure.JwkFailure;
 
 public class JwkException extends BaseException {
     public JwkException(JwkFailure failure) {

--- a/src/main/java/sopt/makers/jwt/verifier/exception/JwtException.java
+++ b/src/main/java/sopt/makers/jwt/verifier/exception/JwtException.java
@@ -1,0 +1,9 @@
+package sopt.makers.jwt.verifier.exception;
+
+import sopt.makers.jwt.verifier.code.JwtFailure;
+
+public class JwtException extends BaseException {
+    public JwtException(JwtFailure failure) {
+        super(failure);
+    }
+}

--- a/src/main/java/sopt/makers/jwt/verifier/exception/JwtException.java
+++ b/src/main/java/sopt/makers/jwt/verifier/exception/JwtException.java
@@ -1,6 +1,6 @@
 package sopt.makers.jwt.verifier.exception;
 
-import sopt.makers.jwt.verifier.code.JwtFailure;
+import sopt.makers.jwt.verifier.code.failure.JwtFailure;
 
 public class JwtException extends BaseException {
     public JwtException(JwtFailure failure) {

--- a/src/main/java/sopt/makers/jwt/verifier/infrastructure/JwkProvider.java
+++ b/src/main/java/sopt/makers/jwt/verifier/infrastructure/JwkProvider.java
@@ -1,4 +1,4 @@
-package sopt.makers.jwt.verifier.jwk;
+package sopt.makers.jwt.verifier.infrastructure;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/src/main/java/sopt/makers/jwt/verifier/infrastructure/JwkProvider.java
+++ b/src/main/java/sopt/makers/jwt/verifier/infrastructure/JwkProvider.java
@@ -13,7 +13,7 @@ import java.text.ParseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import sopt.makers.jwt.verifier.code.jwk.JwkFailure;
+import sopt.makers.jwt.verifier.code.failure.JwkFailure;
 import sopt.makers.jwt.verifier.exception.JwkException;
 
 import java.security.PublicKey;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -8,3 +8,4 @@ jwt:
   jwk:
     url: ${DEV_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
+    issuer: ${MAKERS_AUTH_JWK_ISSUER}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -8,3 +8,4 @@ jwt:
   jwk:
     url: ${PROD_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
+    issuer: ${MAKERS_AUTH_JWK_ISSUER}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -8,3 +8,4 @@ jwt:
   jwk:
     url: ${DEV_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
+    issuer: ${MAKERS_AUTH_JWK_ISSUER}


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## ✨ 변경 사항 요약
- JWT 토큰의 파싱, 검증, 서브젝트 추출 로직을 구현하였습니다.
- JWK 캐시 사용 중 발생할 수 있는 서명 검증 실패에 대응하여, 캐시 무효화 후 재검증 로직을 추가하였습니다.
- resolve #2

## 🔧 주요 구현 내용
- **토큰 파싱 및 공개키 조회:**  
  - `SignedJWT.parse(token)`을 통해 JWT를 파싱하고, JWT 헤더의 Key ID (kid)를 이용해 `JwkProvider`에서 공개키를 조회합니다.
- **JWT 검증**  
  - `verify` 메서드에서 RSASSA 서명 검증(`RSASSAVerifier`)과 함께, issuer와 만료시간을 확인합니다.  
  - 각 검증 항목 (서명, issuer, 만료 여부)의 결과를 로깅하여 어느 부분이 유효하지 않은지를 확인합니다.
- **재검증 로직**  
  - 서명 검증 중 `JOSEException`이 발생하면, `retryVerification` 메서드를 통해 다음과 같은 과정을 거칩니다
    1. 기존의 키 캐시를 무효화하고,
    2. 새로운 공개키를 조회한 후 다시 검증을 시도합니다.
  - 만약 재검증에도 실패하면 `JwtException`을 던집니다.
- **예외 처리** 
  - JWT 파싱 실패, 검증 실패 (클레임 불일치, 서명 불일치, 만료 등) 시 각각 적절한 `JwtFailure` 코드로 예외를 던집니다.

## 📝 참고 사항
- 내부적으로는 실패한 클레임 조건(서명, issuer, 만료 여부)을 로깅하나, 사용자에게는 통합된 예외 메시지(`JWT_INVALID_CLAIMS` 또는 `JWT_VERIFICATION_FAILED`)를 전달합니다.
- 현재 공개키 조회에 대해 x-api-key를 설정하는 코드가 누락되어 있어 issue 생성 후 수정하겠습니다!

