### PR TITLE
feat: 공개키 조회 로직에 header 설정 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	implementation("org.slf4j:slf4j-api:2.0.9")
 	implementation("org.projectlombok:lombok:1.18.30")
 	annotationProcessor("org.projectlombok:lombok:1.18.30")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/java/sopt/makers/jwt/verifier/JwtJwkVerifierApplication.java
+++ b/src/main/java/sopt/makers/jwt/verifier/JwtJwkVerifierApplication.java
@@ -2,8 +2,11 @@ package sopt.makers.jwt.verifier;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import sopt.makers.jwt.verifier.config.property.AuthClientProperty;
 
 @SpringBootApplication
+@EnableConfigurationProperties(AuthClientProperty.class)
 public class JwtJwkVerifierApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/sopt/makers/jwt/verifier/application/JwkProvider.java
+++ b/src/main/java/sopt/makers/jwt/verifier/application/JwkProvider.java
@@ -1,4 +1,4 @@
-package sopt.makers.jwt.verifier.infrastructure;
+package sopt.makers.jwt.verifier.application;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -12,7 +12,9 @@ import java.text.ParseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import sopt.makers.jwt.verifier.code.failure.JwkFailure;
+import sopt.makers.jwt.verifier.exception.ClientException;
 import sopt.makers.jwt.verifier.exception.JwkException;
+import sopt.makers.jwt.verifier.infrastructure.AuthClient;
 
 import java.security.PublicKey;
 import java.time.Duration;
@@ -47,7 +49,7 @@ public class JwkProvider {
             JWKSet jwkSet = loadJwkSet();
             JWK jwk = findJwkByKeyId(jwkSet, kid);
             return convertToPublicKey(jwk);
-        } catch (JwkException e) {
+        } catch (JwkException | ClientException e) {
             throw e;
         } catch (RuntimeException | IOException | ParseException e) {
             log.error(e.getMessage());
@@ -55,7 +57,7 @@ public class JwkProvider {
         }
     }
 
-    private JWKSet loadJwkSet() throws IOException, ParseException {
+    private JWKSet loadJwkSet() throws IOException, ParseException, ClientException {
         String json = authClient.getJwk();
         return JWKSet.parse(json);
     }

--- a/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
+++ b/src/main/java/sopt/makers/jwt/verifier/application/JwtVerifier.java
@@ -17,7 +17,6 @@ import java.text.ParseException;
 import sopt.makers.jwt.verifier.code.failure.JwtFailure;
 import sopt.makers.jwt.verifier.exception.JwtException;
 import sopt.makers.jwt.verifier.exception.JwkException;
-import sopt.makers.jwt.verifier.infrastructure.JwkProvider;
 
 @Slf4j
 @Component

--- a/src/main/java/sopt/makers/jwt/verifier/code/failure/ClientFailure.java
+++ b/src/main/java/sopt/makers/jwt/verifier/code/failure/ClientFailure.java
@@ -1,0 +1,18 @@
+package sopt.makers.jwt.verifier.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import sopt.makers.jwt.verifier.code.base.FailureCode;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum ClientFailure implements FailureCode {
+  RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 서버 응답 오류"),
+  COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"외부 서버 통신 실패");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/sopt/makers/jwt/verifier/config/WebClientConfig.java
+++ b/src/main/java/sopt/makers/jwt/verifier/config/WebClientConfig.java
@@ -1,0 +1,24 @@
+package sopt.makers.jwt.verifier.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import sopt.makers.jwt.verifier.config.property.AuthClientProperty;
+
+@Configuration
+public class WebClientConfig {
+    public static final String HEADER_API_KEY = "X-Api-Key";
+    public static final String HEADER_SERVICE_NAME = "X-Service-Name";
+
+    @Bean
+    public WebClient authWebClient(AuthClientProperty property) {
+        return WebClient.builder()
+                .baseUrl(property.url())
+                .defaultHeader(HEADER_API_KEY, property.apiKey())
+                .defaultHeader(HEADER_SERVICE_NAME, property.serviceName())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/sopt/makers/jwt/verifier/config/WebClientConfig.java
+++ b/src/main/java/sopt/makers/jwt/verifier/config/WebClientConfig.java
@@ -1,24 +1,45 @@
 package sopt.makers.jwt.verifier.config;
 
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 import sopt.makers.jwt.verifier.config.property.AuthClientProperty;
+
+import java.time.Duration;
 
 @Configuration
 public class WebClientConfig {
+
     public static final String HEADER_API_KEY = "X-Api-Key";
     public static final String HEADER_SERVICE_NAME = "X-Service-Name";
+    private static final int TIMEOUT_MILLIS = 5000;
+    private static final int TIMEOUT_SECONDS = 5;
 
     @Bean
     public WebClient authWebClient(AuthClientProperty property) {
         return WebClient.builder()
                 .baseUrl(property.url())
+                .clientConnector(new ReactorClientHttpConnector(createDefaultHttpClient()))
                 .defaultHeader(HEADER_API_KEY, property.apiKey())
                 .defaultHeader(HEADER_SERVICE_NAME, property.serviceName())
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .build();
+    }
+
+    private HttpClient createDefaultHttpClient() {
+        return HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, TIMEOUT_MILLIS)
+                .responseTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(TIMEOUT_SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(TIMEOUT_SECONDS))
+                );
     }
 }

--- a/src/main/java/sopt/makers/jwt/verifier/config/property/AuthClientProperty.java
+++ b/src/main/java/sopt/makers/jwt/verifier/config/property/AuthClientProperty.java
@@ -1,0 +1,13 @@
+package sopt.makers.jwt.verifier.config.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.auth")
+public record AuthClientProperty(
+        String url,
+        String apiKey,
+        String serviceName,
+        Endpoints endpoints
+) {
+    public record Endpoints(String jwk) {}
+}

--- a/src/main/java/sopt/makers/jwt/verifier/exception/ClientException.java
+++ b/src/main/java/sopt/makers/jwt/verifier/exception/ClientException.java
@@ -1,0 +1,9 @@
+package sopt.makers.jwt.verifier.exception;
+
+import sopt.makers.jwt.verifier.code.failure.ClientFailure;
+
+public class ClientException extends BaseException {
+    public ClientException(ClientFailure failure) {
+        super(failure);
+    }
+}

--- a/src/main/java/sopt/makers/jwt/verifier/infrastructure/AuthClient.java
+++ b/src/main/java/sopt/makers/jwt/verifier/infrastructure/AuthClient.java
@@ -1,0 +1,36 @@
+package sopt.makers.jwt.verifier.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import sopt.makers.jwt.verifier.code.failure.ClientFailure;
+import sopt.makers.jwt.verifier.config.property.AuthClientProperty;
+import sopt.makers.jwt.verifier.exception.ClientException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthClient {
+
+    private final WebClient authWebClient;
+    private final AuthClientProperty authProperty;
+
+    public String getJwk() {
+        try {
+            return authWebClient.get()
+                    .uri(authProperty.endpoints().jwk())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .onErrorMap(WebClientResponseException.class, ex -> {
+                        log.error("Failed to receive response from Auth server: {}", ex.getResponseBodyAsString(), ex);
+                        return new ClientException(ClientFailure.RESPONSE_ERROR);
+                    })
+                    .block();
+        } catch (RuntimeException e) {
+            log.error("Unexpected exception occurred during Auth server communication: {}", e.getMessage(), e);
+            throw new ClientException(ClientFailure.COMMUNICATION_ERROR);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,6 +6,13 @@ spring:
 
 jwt:
   jwk:
-    url: ${DEV_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
     issuer: ${MAKERS_AUTH_JWK_ISSUER}
+
+external:
+  auth:
+    url: https://auth.api.dev.sopt.org
+    api-key: ${AUTH_API_KEY}
+    service-name: ${OUR_SERVICE_NAME}
+    endpoints:
+      jwk: ${MAKERS_AUTH_JWK_ENDPOINT}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -6,6 +6,13 @@ spring:
 
 jwt:
   jwk:
-    url: ${PROD_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
     issuer: ${MAKERS_AUTH_JWK_ISSUER}
+
+external:
+  auth:
+    url: https://auth.api.sopt.org
+    api-key: ${AUTH_API_KEY}
+    service-name: ${OUR_SERVICE_NAME}
+    endpoints:
+      jwk: ${MAKERS_AUTH_JWK_ENDPOINT}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -6,6 +6,13 @@ spring:
 
 jwt:
   jwk:
-    url: ${DEV_MAKERS_AUTH_JWK_URL}
     key-id: ${MAKERS_AUTH_JWK_KEY_ID}
     issuer: ${MAKERS_AUTH_JWK_ISSUER}
+
+external:
+  auth:
+    url: https://auth.api.dev.sopt.org
+    api-key: ${AUTH_API_KEY}
+    service-name: ${OUR_SERVICE_NAME}
+    endpoints:
+      jwk: ${MAKERS_AUTH_JWK_ENDPOINT}


### PR DESCRIPTION
<!--
name: Makers Auth Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## ✨ 변경 사항 요약
- 기존에는 JwkProvider에서 직접 외부 인증 서버의 JWK 정보를 조회하고 있었습니다
- 그러나 해당 방식은 커스텀 header를 설정하기 어렵다는 점과 외부 통신 로직이 혼재되어있어 책임 분리를 위해 AuthClient(WebClient 기반)를 도입하고 의존성을 분리했습니다.
- resolve #6

## 🔧 주요 구현 내용
- **외부 인증 서버 통신 로직 개선**
  - `AuthClientProperty:` 인증 서버 정보(baseUrl, apiKey, serviceName, endpoints)를 외부 설정으로 분리하였습니다
  - `WebClientConfig`: 인증 서버 전용 WebClient를 생성해주었습니다
  - `AuthClient`: 인증 서버로부터 JWK JSON을 받아오는 책임을 단일화한 클라이언트 클래스를 구현했습니다
```
public WebClient authWebClient(AuthClientProperty property) {
        return WebClient.builder()
                .baseUrl(property.url())
                .defaultHeader(HEADER_API_KEY, property.apiKey())
                .defaultHeader(HEADER_SERVICE_NAME, property.serviceName())
                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                .build();
    }
```

- **JwkProvider 리팩토링**
  - JwkProvider가 더 이상 직접 URL을 통해 통신하지 않고 AuthClient를 통해 공개키를 조회해 올 수 있도록 리팩토링해주었습니다

- **외부 서버 통신 실패에 대한 ClientException 및 ClientFailure 코드 추가**
  - 외부 요청 실패를 위한 공통 예외 클래스 ClientException 및 ClientFailure 코드 추가
  - JWK 조회 실패 시, 적절한 예외로 매핑되어 내부 오류 및 통신 오류 구분이 가능하도록 로직을 구현했습니다

## 📝 참고 사항
- 인증 서버에서 공개키 조회 형식에 문제가 있어 이를 수정한 후에 로컬에서 두 서버 간의 통신이 원활한지까지 테스트를 완료했습니다!
- [인증 서버 공개키 조회 문제 수정 PR](https://github.com/sopt-makers/sopt-auth-backend/pull/72)
- 연동을 위한 테스트 컨트롤러 응답 확인
<img width="819" alt="image" src="https://github.com/user-attachments/assets/253edd0a-18d3-4894-b2ef-1b0ab8413756" />

- 캐싱 적용 확인
<img width="823" alt="image" src="https://github.com/user-attachments/assets/7e26fbfd-1366-4aa9-bc60-cfa7d0e466f8" />


